### PR TITLE
Apply policy for org.clojure::clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.2"]])
+  :dependencies [[org.clojure/clojure "1.9.1"]])


### PR DESCRIPTION
Apply policy `clojure-project-deps::org.clojure::clojure`:

**New Library Target**
Target version for library *org.clojure/clojure* is *1.9.1*.  Currently *1.9.2* in *workflow-play/wf1*

_Lein dependencies_
```org.clojure::clojure (org.clojure::clojure@1.9.1)```

[fingerprint:clojure-project-deps::org.clojure::clojure=af44ff8590063692a3f522aa77bcaf7a2b9d18a391dee70191061425ab6b62f5]

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code>
</details>